### PR TITLE
Implement email crawler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,6 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# pycharm
+.idea/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# Email crawler
+
+A simple command-line tool for crawling a domain for email addresses.
+
+## Installation
+```bash
+git clone https://github.com/hchasestevens/email-crawler
+cd email-crawler
+pip install .
+```
+
+## Example usage
+```bash
+$ find-emails www.chasestevens.com
+Found these email addresses:
+chase@chasestevens.com
+roger.crisp@st-annes-oxford.ac.uk
+```
+
+## Uninstallation
+```bash
+pip uninstall email_crawler
+```

--- a/email_crawler/cli.py
+++ b/email_crawler/cli.py
@@ -1,0 +1,22 @@
+#!/usr/bin/python
+
+"""Command-line interface for email crawler."""
+
+import argparse
+
+from email_crawler import crawler
+
+parser = argparse.ArgumentParser()
+parser.add_argument('url', help='initial URL or domain', type=str)
+
+
+def main():
+    """Entrypoint for CLI."""
+    args = parser.parse_args()
+    print("Found these email addresses:")
+    for email_address in crawler.crawl_emails(args.url):
+        print(email_address)
+
+
+if __name__ == '__main__':
+    main()

--- a/email_crawler/crawler.py
+++ b/email_crawler/crawler.py
@@ -1,0 +1,86 @@
+"""Utilities for crawling and scraping emails."""
+
+from email.utils import getaddresses
+from itertools import chain
+from multiprocessing import cpu_count
+from multiprocessing.pool import ThreadPool
+from typing import Set, NamedTuple, Optional, Iterable
+from urllib.parse import urlparse, urljoin
+
+from lxml import etree
+import requests
+from requests.utils import prepend_scheme_if_needed
+
+REQUEST_TIMEOUT_SECONDS = 10.0
+
+FetchResult = NamedTuple('FetchResult', (
+    ('url', str),
+    ('successful', bool),
+    ('page', Optional[etree.Element])
+))
+
+
+def linked_urls(page: etree.Element, base_url: str) -> Set[str]:
+    """Return hyperlinked urls from page within same domain."""
+    urls = (
+        urljoin(base_url, url)
+        for url in page.xpath("//a/@href")
+    )
+    target_domain = urlparse(base_url).netloc
+    return {
+        url
+        for url in urls
+        if urlparse(url).netloc == target_domain
+    }
+
+
+def emails(page: etree.Element) -> Set[str]:
+    """Extract email addresses from given page."""
+    return {
+        address.split('?', 1)[0]
+        for _, address in getaddresses(
+            page.xpath("//a[starts-with(@href, 'mailto:')]/@href")
+        )
+        if '@' in address
+    }
+
+
+def fetch(url: str, timeout_seconds: float = REQUEST_TIMEOUT_SECONDS) -> FetchResult:
+    try:
+        page = etree.HTML(
+            requests.get(url, timeout=timeout_seconds).content
+        )
+    except Exception:
+        page = None
+    return FetchResult(
+        url=url,
+        successful=page is not None,
+        page=page
+    )
+
+
+def crawl_emails(initial_url: str) -> Iterable[str]:
+    """Emit email addresses discovered by crawling the specified URL."""
+    frontier = {prepend_scheme_if_needed(initial_url, 'http'),}
+    visited_urls = set()
+    emitted_emails = set()
+
+    with ThreadPool(processes=cpu_count()) as pool:
+        while frontier:
+            results = pool.map_async(fetch, frontier).get()
+            visited_urls.update(result.url for result in results)
+            successful_results = [result for result in results if result.successful]
+
+            frontier = {
+                url.lower()
+                for result in successful_results
+                for url in linked_urls(result.page, result.url)
+            } - visited_urls
+
+            scraped_emails = {
+                email.lower()
+                for r in successful_results
+                for email in emails(r.page)
+            } - emitted_emails
+            yield from scraped_emails
+            emitted_emails.update(scraped_emails)

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,22 @@
+"""Setup for astpath, adds astpath console_script."""
+
+from setuptools import setup
+
+setup(
+    name='email_crawler',
+    packages=['email_crawler'],
+    version='0.0.1',
+    description='A command-line utility for crawling for emails',
+    author='H. Chase Stevens',
+    author_email='chase@chasestevens.com',
+    url='https://github.com/hchasestevens/email-crawler',
+    install_requires={
+        'lxml>=4.1.1',
+        'requests>=2.18.4',
+    },
+    entry_points={
+        'console_scripts': [
+            'find-emails = email_crawler.cli:main',
+        ]
+    },
+)


### PR DESCRIPTION
This PR:
- Implements the email crawler
- Adds a setup.py
- Adds a README.md

Some notes: 
- I've made the assumption that we only want emails specified within `mailto:` links - not those within the text of the page. 
- There is a hard timeout of 10 seconds for page requests, and a hard limit of threads equal to the number of CPUs on the system. 
- Email address casing is not preserved; additionally, URL casing is not respected, so we will fail to follow some URLs in case-sensitive situations (e.g. case-sensitive GET parameters or unusual web server/server configurations).